### PR TITLE
Halt dark theme until new design

### DIFF
--- a/app/src/main/java/com/example/bookshelf/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/bookshelf/ui/theme/Theme.kt
@@ -39,7 +39,7 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun BookshelfTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    darkTheme: Boolean = false,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit


### PR DESCRIPTION
Stops the app from loading in dark theme by default, at the moment there are no design for dark scheme